### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+build/
+archive/
+*.so
+*.csv
+nmars*.*
+pmars*.*
+arena?/
+nunit.framework.dll
+SDL.dll
+instructions.txt
+*.bak
+nano.txt
+both.txt
+std.txt
+tiny.txt
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install build tools for the C++ worker
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ cmake make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Build the optional C++ worker library
+RUN g++ -std=c++17 -shared -fPIC redcode-worker.cpp -o redcode_worker.so
+
+# Default command runs the evolver
+CMD ["python", "evolverstage.py"]

--- a/README.md
+++ b/README.md
@@ -107,3 +107,19 @@ export REDCODE_TRACE_FILE=trace.log
 ```
 
 Omit the variable to disable tracing.
+
+## Docker
+
+A `Dockerfile` is provided to run the evolver in an isolated environment. Build the image with:
+
+```
+docker build -t corewar-evolver .
+```
+
+Run the evolver:
+
+```
+docker run --rm -it corewar-evolver
+```
+
+The build step compiles the optional C++ worker (`redcode-worker.cpp`) so the library is ready to use inside the container.


### PR DESCRIPTION
## Summary
- Add Dockerfile that installs build tools, compiles the C++ worker, and runs the evolver by default
- Introduce `.dockerignore` to keep the Docker build context lean
- Document Docker workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5059356188330a5861ae128a6c19f