### PR TITLE
Add multi-round internal battles with scoring

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -56,7 +56,8 @@ try:
     CPP_WORKER_LIB.run_battle.argtypes = [
         ctypes.c_char_p, ctypes.c_int,
         ctypes.c_char_p, ctypes.c_int,
-        ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int
+        ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+        ctypes.c_int
     ]
     CPP_WORKER_LIB.run_battle.restype = ctypes.c_char_p
     print("Successfully loaded C++ Redcode worker.")
@@ -122,7 +123,8 @@ def run_internal_battle(arena, cont1, cont2, coresize, cycles, processes, warlen
             coresize,
             cycles,
             processes,
-            wardistance
+            wardistance,
+            battlerounds
         )
 
         # 3. Decode the result

--- a/tests/test_redcode_worker.py
+++ b/tests/test_redcode_worker.py
@@ -28,18 +28,19 @@ def load_worker():
         ctypes.c_int,
         ctypes.c_int,
         ctypes.c_int,
+        ctypes.c_int,
     ]
     lib.run_battle.restype = ctypes.c_char_p
     return lib
 
 
-def get_process_counts(result_str):
+def get_scores(result_str):
     lines = result_str.strip().splitlines()
-    counts = []
+    scores = []
     for line in lines:
         parts = line.split()
-        counts.append(int(parts[4]))
-    return counts
+        scores.append(int(parts[4]))
+    return scores
 
 
 def test_validate_self_tie():
@@ -48,12 +49,13 @@ def test_validate_self_tie():
     code_path = base_path / "Validate1_1R_assembled.txt"
     with open(code_path, "r") as f:
         code = f.read()
+    rounds = 5
     result = lib.run_battle(
         code.encode(), 1,
         code.encode(), 2,
-        8000, 10000, 8000, 100
+        8000, 10000, 8000, 100, rounds
     ).decode()
-    w1_procs, w2_procs = get_process_counts(result)
-    assert w1_procs == w2_procs, (
-        "Validate1.1R should result in a tie, got: " + result
+    w1_score, w2_score = get_scores(result)
+    assert w1_score == w2_score == rounds, (
+        "Validate1.1R should score " + str(rounds) + " each, got: " + result
     )


### PR DESCRIPTION
## Summary
- extend Python bridge to pass battleround count to C++ worker
- run multiple rounds in C++ core battle engine and accumulate scores (3 per win, 1 per draw)
- test that multiple rounds return expected total scores

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50fe096a88330a53142089edeafd7