### PR TITLE
Improve redcode parser error handling

### DIFF
--- a/tests/test_redcode_worker.py
+++ b/tests/test_redcode_worker.py
@@ -59,3 +59,15 @@ def test_validate_self_tie():
     assert w1_score == w2_score == rounds, (
         "Validate1.1R should score " + str(rounds) + " each, got: " + result
     )
+
+
+def test_invalid_operand_returns_error():
+    lib = load_worker()
+    invalid_code = "MOV.I #abc, $0\n"
+    result = lib.run_battle(
+        invalid_code.encode(), 1,
+        invalid_code.encode(), 2,
+        8000, 1000, 8000, 100, 1
+    ).decode()
+    assert result.startswith("ERROR:"), f"Expected error response, got: {result}"
+    assert "Invalid numeric operand" in result


### PR DESCRIPTION
## Summary
- validate redcode parsing by requiring known opcodes/modifiers and numeric operands, and surface parsing failures with contextual errors
- ensure battle execution reports parsing problems instead of defaulting to fabricated instructions
- add a regression test that expects an error response for malformed operands

## Testing
- pytest tests/test_redcode_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68c871150edc8330a4eb22a0807e52d1