### PR TITLE
Stop battles once outcome decided

### DIFF
--- a/redcode-worker.cpp
+++ b/redcode-worker.cpp
@@ -642,6 +642,7 @@ extern "C" {
             int w1_score = 0;
             int w2_score = 0;
 
+            int rounds_played = 0;
             for (int r = 0; r < rounds; ++r) {
                 Core core(core_size, trace_file);
                 std::uniform_int_distribution<> distrib(0, core_size - 1);
@@ -691,6 +692,17 @@ extern "C" {
                 } else {
                     w1_score += 1;
                     w2_score += 1;
+                }
+
+                rounds_played = r + 1;
+                int rounds_remaining = rounds - rounds_played;
+                int score_diff = w1_score - w2_score;
+                int max_possible_swing = 3 * rounds_remaining;
+                if (score_diff > 0 && score_diff > max_possible_swing) {
+                    break;
+                }
+                if (score_diff < 0 && -score_diff > max_possible_swing) {
+                    break;
                 }
             }
 

--- a/tests/test_redcode_worker.py
+++ b/tests/test_redcode_worker.py
@@ -99,3 +99,23 @@ def test_org_pseudo_opcode_rejected():
     ).decode()
     assert result.startswith("ERROR:"), f"Expected ORG to be rejected, got: {result}"
     assert "Unsupported pseudo-opcode 'ORG'" in result
+
+
+def test_battle_stops_once_outcome_decided():
+    lib = load_worker()
+    dominant_warrior = "JMP 0\n"
+    fragile_warrior = "DAT.F #0, #0\n"
+    rounds = 100
+    result = lib.run_battle(
+        dominant_warrior.encode(), 1,
+        fragile_warrior.encode(), 2,
+        8000, 50, 8000, 1, rounds
+    ).decode()
+    w1_score, w2_score = get_scores(result)
+    assert w2_score == 0, f"Expected fragile warrior to lose every round, got scores {w1_score}, {w2_score}"
+    expected_rounds_played = (rounds // 2) + 1
+    expected_score = expected_rounds_played * 3
+    assert w1_score == expected_score, (
+        "Battle should stop once the outcome is locked; "
+        f"expected leader score {expected_score} for {expected_rounds_played} rounds, got {w1_score}"
+    )


### PR DESCRIPTION
## Summary
- exit the battle loop early when the score gap exceeds the maximum points available to the trailing warrior
- add a regression test covering the early-stop behaviour with a deterministic dominant warrior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c995bb2c5c8330853d12298882f4e7