### PR TITLE
Refactor random instruction generation and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.git
 *.csv
 nmars*.*
 pmars*.*

--- a/README.md
+++ b/README.md
@@ -94,7 +94,21 @@ Results of battles saved so you can analyse your progress. Current fields are 'e
 
 ## Compiling `redcode-worker.cpp`
 
-An experimental C++ worker (`redcode-worker.cpp`) can be built as a shared library for use with the Python evolver. Compile it with g++:
+An experimental C++ worker (`redcode-worker.cpp`) can be built as a shared library for use with the Python evolver.
+
+### Building with CMake (recommended)
+
+We recommend using CMake to build the C++ worker, as it handles platform differences automatically.
+
+1.  Create a build directory: `mkdir build && cd build`
+2.  Run CMake: `cmake ..`
+3.  Compile: `cmake --build .`
+
+This will place the compiled library (`redcode_worker.so`, `.dll`, or `.dylib`) in the project's root directory.
+
+### Building with g++
+
+If you prefer compiling directly with `g++`, use the following command:
 
 ```
 g++ -std=c++17 -shared -fPIC redcode-worker.cpp -o redcode_worker.so


### PR DESCRIPTION
## Summary
- add a helper to generate random instructions and reuse it during seeding and major mutations
- refactor the nmars command construction to use a descriptive argument mapping
- document the recommended CMake build process and synchronize ignore files

## Testing
- python -m compileall evolverstage.py

------
https://chatgpt.com/codex/tasks/task_e_68d45a451924833081e37fe0d170d97a