### PR TITLE
Handle missing operands without assumptions

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -128,11 +128,15 @@ def run_internal_battle(arena, cont1, cont2, coresize, cycles, processes, warlen
 
         # 3. Decode the result
         result_str = result_ptr.decode('utf-8')
+        if result_str.strip().startswith("ERROR:"):
+            raise RuntimeError(
+                f"C++ worker reported an error: {result_str.strip()}"
+            )
         return result_str
 
     except Exception as e:
         raise RuntimeError(
-            "An error occurred while running the internal battle"
+            f"An error occurred while running the internal battle: {e}"
         ) from e
 
 def read_config(key, data_type='int', default=None):

--- a/redcode-worker.cpp
+++ b/redcode-worker.cpp
@@ -224,13 +224,12 @@ Instruction parse_line(const std::string& line) {
     std::string a_str;
     std::string b_str;
     size_t comma_pos = operands_str.find(',');
-    if (comma_pos != std::string::npos) {
-        a_str = trim(operands_str.substr(0, comma_pos));
-        b_str = trim(operands_str.substr(comma_pos + 1));
-    } else {
-        a_str = trim(operands_str);
-        b_str = "$0"; // Default for missing B-field
+    if (comma_pos == std::string::npos) {
+        throw std::runtime_error("Missing B-field operand in line: " + original_line);
     }
+
+    a_str = trim(operands_str.substr(0, comma_pos));
+    b_str = trim(operands_str.substr(comma_pos + 1));
 
     if (a_str.empty()) {
         throw std::runtime_error("Missing A-field operand in line: " + original_line);


### PR DESCRIPTION
## Summary
- stop the C++ parser from defaulting missing B-field operands and instead raise an error when an instruction omits the field
- surface C++ worker errors through the Python bridge so the evolutionary run terminates with a clear message

## Testing
- python -m compileall evolverstage.py

------
https://chatgpt.com/codex/tasks/task_e_68d45cac312483309ae7b88705f33a9e