### PR TITLE
Refactor configuration handling into dataclass

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -12,6 +12,95 @@ import re
 from dataclasses import dataclass
 from typing import Optional
 
+
+@dataclass
+class EvolverConfig:
+    battle_engine: str
+    last_arena: int
+    coresize_list: list[int]
+    sanitize_list: list[int]
+    cycles_list: list[int]
+    processes_list: list[int]
+    warlen_list: list[int]
+    wardistance_list: list[int]
+    numwarriors: int
+    alreadyseeded: bool
+    clock_time: float
+    battle_log_file: Optional[str]
+    final_era_only: bool
+    nothing_list: list[int]
+    random_list: list[int]
+    nab_list: list[int]
+    mini_mut_list: list[int]
+    micro_mut_list: list[int]
+    library_list: list[int]
+    magic_number_list: list[int]
+    archive_list: list[int]
+    unarchive_list: list[int]
+    library_path: Optional[str]
+    crossoverrate_list: list[int]
+    transpositionrate_list: list[int]
+    battlerounds_list: list[int]
+    prefer_winner_list: list[bool]
+    instr_set: list[str]
+    instr_modes: list[str]
+    instr_modif: list[str]
+
+
+def load_configuration(path: str) -> EvolverConfig:
+    parser = configparser.ConfigParser()
+    read_files = parser.read(path)
+    if not read_files:
+        raise FileNotFoundError(f"Configuration file '{path}' not found")
+
+    def _read_config(key: str, data_type: str = 'int', default=None):
+        value = parser['DEFAULT'].get(key, fallback=default)
+        if value in (None, ''):
+            return default
+
+        data_type_mapping = {
+            'int': int,
+            'int_list': lambda x: [int(i) for i in x.split(',')],
+            'bool_list': lambda x: [s.strip().lower() == 'true' for s in x.split(',') if s.strip()],
+            'string_list': lambda x: [i.strip() for i in x.split(',') if i.strip()],
+            'bool': lambda x: parser['DEFAULT'].getboolean(key, fallback=default),
+            'float': float,
+        }
+        return data_type_mapping.get(data_type, lambda x: x.strip() or None)(value)
+
+    return EvolverConfig(
+        battle_engine=_read_config('BATTLE_ENGINE', data_type='string', default='external') or 'external',
+        last_arena=_read_config('LAST_ARENA', data_type='int'),
+        coresize_list=_read_config('CORESIZE_LIST', data_type='int_list') or [],
+        sanitize_list=_read_config('SANITIZE_LIST', data_type='int_list') or [],
+        cycles_list=_read_config('CYCLES_LIST', data_type='int_list') or [],
+        processes_list=_read_config('PROCESSES_LIST', data_type='int_list') or [],
+        warlen_list=_read_config('WARLEN_LIST', data_type='int_list') or [],
+        wardistance_list=_read_config('WARDISTANCE_LIST', data_type='int_list') or [],
+        numwarriors=_read_config('NUMWARRIORS', data_type='int'),
+        alreadyseeded=_read_config('ALREADYSEEDED', data_type='bool'),
+        clock_time=_read_config('CLOCK_TIME', data_type='float'),
+        battle_log_file=_read_config('BATTLE_LOG_FILE', data_type='string'),
+        final_era_only=_read_config('FINAL_ERA_ONLY', data_type='bool'),
+        nothing_list=_read_config('NOTHING_LIST', data_type='int_list') or [],
+        random_list=_read_config('RANDOM_LIST', data_type='int_list') or [],
+        nab_list=_read_config('NAB_LIST', data_type='int_list') or [],
+        mini_mut_list=_read_config('MINI_MUT_LIST', data_type='int_list') or [],
+        micro_mut_list=_read_config('MICRO_MUT_LIST', data_type='int_list') or [],
+        library_list=_read_config('LIBRARY_LIST', data_type='int_list') or [],
+        magic_number_list=_read_config('MAGIC_NUMBER_LIST', data_type='int_list') or [],
+        archive_list=_read_config('ARCHIVE_LIST', data_type='int_list') or [],
+        unarchive_list=_read_config('UNARCHIVE_LIST', data_type='int_list') or [],
+        library_path=_read_config('LIBRARY_PATH', data_type='string'),
+        crossoverrate_list=_read_config('CROSSOVERRATE_LIST', data_type='int_list') or [],
+        transpositionrate_list=_read_config('TRANSPOSITIONRATE_LIST', data_type='int_list') or [],
+        battlerounds_list=_read_config('BATTLEROUNDS_LIST', data_type='int_list') or [],
+        prefer_winner_list=_read_config('PREFER_WINNER_LIST', data_type='bool_list') or [],
+        instr_set=_read_config('INSTR_SET', data_type='string_list') or [],
+        instr_modes=_read_config('INSTR_MODES', data_type='string_list') or [],
+        instr_modif=_read_config('INSTR_MODIF', data_type='string_list') or [],
+    )
+
 class DataLogger:
     def __init__(self, filename):
         self.filename = filename
@@ -139,57 +228,11 @@ def run_internal_battle(arena, cont1, cont2, coresize, cycles, processes, warlen
             f"An error occurred while running the internal battle: {e}"
         ) from e
 
-def read_config(key, data_type='int', default=None):
-    value = config['DEFAULT'].get(key, fallback=default)
-    if not value:
-        return default
-    data_type_mapping = {
-        'int': int,
-        'int_list': lambda x: [int(i) for i in x.split(',')],
-        'bool_list': lambda x: [s.strip().lower() == 'true' for s in x.split(',') if s.strip()],
-        'string_list': lambda x: [i.strip() for i in x.split(',')],
-        'bool': lambda x: config['DEFAULT'].getboolean(key, default),
-        'float': float,
-    }
-    return data_type_mapping.get(data_type, lambda x: x.strip() or None)(value)
-
-config = configparser.ConfigParser()
-config.read('settings.ini')
-
-BATTLE_ENGINE = read_config('BATTLE_ENGINE', data_type='string', default='external')
-LAST_ARENA = read_config('LAST_ARENA', data_type='int')
-CORESIZE_LIST = read_config('CORESIZE_LIST', data_type='int_list')
-SANITIZE_LIST = read_config('SANITIZE_LIST', data_type='int_list')
-CYCLES_LIST = read_config('CYCLES_LIST', data_type='int_list')
-PROCESSES_LIST = read_config('PROCESSES_LIST', data_type='int_list')
-WARLEN_LIST = read_config('WARLEN_LIST', data_type='int_list')
-WARDISTANCE_LIST = read_config('WARDISTANCE_LIST', data_type='int_list')
-NUMWARRIORS = read_config('NUMWARRIORS', data_type='int')
-ALREADYSEEDED = read_config('ALREADYSEEDED', data_type='bool')
-CLOCK_TIME = read_config('CLOCK_TIME', data_type='float')
-BATTLE_LOG_FILE = read_config('BATTLE_LOG_FILE', data_type='string')
-FINAL_ERA_ONLY = read_config('FINAL_ERA_ONLY', data_type='bool')
-NOTHING_LIST = read_config('NOTHING_LIST', data_type='int_list')
-RANDOM_LIST = read_config('RANDOM_LIST', data_type='int_list')
-NAB_LIST = read_config('NAB_LIST', data_type='int_list')
-MINI_MUT_LIST = read_config('MINI_MUT_LIST', data_type='int_list')
-MICRO_MUT_LIST = read_config('MICRO_MUT_LIST', data_type='int_list')
-LIBRARY_LIST = read_config('LIBRARY_LIST', data_type='int_list')
-MAGIC_NUMBER_LIST = read_config('MAGIC_NUMBER_LIST', data_type='int_list')
-ARCHIVE_LIST = read_config('ARCHIVE_LIST', data_type='int_list')
-UNARCHIVE_LIST = read_config('UNARCHIVE_LIST', data_type='int_list')
-LIBRARY_PATH = read_config('LIBRARY_PATH', data_type='string')
-CROSSOVERRATE_LIST = read_config('CROSSOVERRATE_LIST', data_type='int_list')
-TRANSPOSITIONRATE_LIST = read_config('TRANSPOSITIONRATE_LIST', data_type='int_list')
-BATTLEROUNDS_LIST = read_config('BATTLEROUNDS_LIST', data_type='int_list')
-PREFER_WINNER_LIST = read_config('PREFER_WINNER_LIST', data_type='bool_list')
-INSTR_SET = read_config('INSTR_SET', data_type='string_list')
-INSTR_MODES = read_config('INSTR_MODES', data_type='string_list')
-INSTR_MODIF = read_config('INSTR_MODIF', data_type='string_list')
+config = load_configuration('settings.ini')
 
 DEFAULT_MODE = '$'
 DEFAULT_MODIFIER = 'F'
-ADDRESSING_MODES = set(INSTR_MODES) if INSTR_MODES else set()
+ADDRESSING_MODES = set(config.instr_modes) if config.instr_modes else set()
 ADDRESSING_MODES.update({'$', '#', '@', '<', '>', '*', '{', '}'})
 
 CANONICAL_SUPPORTED_OPCODES = {
@@ -208,8 +251,8 @@ def canonicalize_opcode(opcode: str) -> str:
 
 GENERATION_OPCODE_POOL = []
 _invalid_generation_opcodes = set()
-if INSTR_SET:
-    for instr in INSTR_SET:
+if config.instr_set:
+    for instr in config.instr_set:
         normalized = instr.strip().upper()
         if not normalized:
             continue
@@ -431,12 +474,12 @@ def sanitize_instruction(instr: RedcodeInstruction, arena: int) -> RedcodeInstru
     sanitized.a_mode = sanitized.a_mode if sanitized.a_mode in ADDRESSING_MODES else DEFAULT_MODE
     sanitized.b_mode = sanitized.b_mode if sanitized.b_mode in ADDRESSING_MODES else DEFAULT_MODE
     sanitized.a_field = corenorm(
-        coremod(_ensure_int(sanitized.a_field), SANITIZE_LIST[arena]),
-        CORESIZE_LIST[arena],
+        coremod(_ensure_int(sanitized.a_field), config.sanitize_list[arena]),
+        config.coresize_list[arena],
     )
     sanitized.b_field = corenorm(
-        coremod(_ensure_int(sanitized.b_field), SANITIZE_LIST[arena]),
-        CORESIZE_LIST[arena],
+        coremod(_ensure_int(sanitized.b_field), config.sanitize_list[arena]),
+        config.coresize_list[arena],
     )
     sanitized.label = None
     return sanitized
@@ -466,20 +509,20 @@ def choose_random_opcode() -> str:
 
 
 def choose_random_modifier() -> str:
-    if INSTR_MODIF:
-        return random.choice(INSTR_MODIF).upper()
+    if config.instr_modif:
+        return random.choice(config.instr_modif).upper()
     return DEFAULT_MODIFIER
 
 
 def choose_random_mode() -> str:
-    if INSTR_MODES:
-        return random.choice(INSTR_MODES)
+    if config.instr_modes:
+        return random.choice(config.instr_modes)
     return DEFAULT_MODE
 
 
 def generate_random_instruction(arena: int) -> RedcodeInstruction:
-    num1 = weighted_random_number(CORESIZE_LIST[arena], WARLEN_LIST[arena])
-    num2 = weighted_random_number(CORESIZE_LIST[arena], WARLEN_LIST[arena])
+    num1 = weighted_random_number(config.coresize_list[arena], config.warlen_list[arena])
+    num2 = weighted_random_number(config.coresize_list[arena], config.warlen_list[arena])
     return RedcodeInstruction(
         opcode=choose_random_opcode(),
         modifier=choose_random_modifier(),
@@ -493,14 +536,14 @@ def create_directory_if_not_exists(directory):
     if not os.path.exists(directory):
         os.mkdir(directory)
 
-if ALREADYSEEDED==False: 
+if not config.alreadyseeded:
   print("Seeding")
   create_directory_if_not_exists("archive")
-  for arena in range (0,LAST_ARENA+1):
+  for arena in range (0,config.last_arena+1):
     create_directory_if_not_exists(f"arena{arena}")
-    for i in range(1, NUMWARRIORS+1):
+    for i in range(1, config.numwarriors+1):
       with open(os.path.join(f"arena{arena}", f"{i}.red"), "w") as f:
-          for j in range(1, WARLEN_LIST[arena]+1):
+          for j in range(1, config.warlen_list[arena]+1):
             #Biasing toward more viable warriors: 3 in 4 chance of choosing an address within the warrior.
             #Same bias in mutation.
             instruction = generate_random_instruction(arena)
@@ -508,7 +551,7 @@ if ALREADYSEEDED==False:
 
 starttime=time.time() #time in seconds
 era=-1
-data_logger = DataLogger(filename=BATTLE_LOG_FILE)
+data_logger = DataLogger(filename=config.battle_log_file)
 
 while(True):
   #before we do anything, determine which era we are in.
@@ -516,39 +559,55 @@ while(True):
   curtime=time.time()
   runtime_in_hours=(curtime-starttime)/60/60
   era=0
-  if runtime_in_hours>CLOCK_TIME*(1/3):
+  if runtime_in_hours>config.clock_time*(1/3):
     era=1
-  if runtime_in_hours>CLOCK_TIME*(2/3):
+  if runtime_in_hours>config.clock_time*(2/3):
     era=2
-  if runtime_in_hours>CLOCK_TIME:
+  if runtime_in_hours>config.clock_time:
     quit()
-  if FINAL_ERA_ONLY==True:
+  if config.final_era_only==True:
     era=2
   if era!=prevera:
     print(f"************** Switching from era {prevera + 1} to {era + 1} *******************")
-    bag = [Marble.DO_NOTHING]*NOTHING_LIST[era] + [Marble.MAJOR_MUTATION]*RANDOM_LIST[era] + \
-          [Marble.NAB_INSTRUCTION]*NAB_LIST[era] + [Marble.MINOR_MUTATION]*MINI_MUT_LIST[era] + \
-          [Marble.MICRO_MUTATION]*MICRO_MUT_LIST[era] + [Marble.INSTRUCTION_LIBRARY]*LIBRARY_LIST[era] + \
-          [Marble.MAGIC_NUMBER_MUTATION]*MAGIC_NUMBER_LIST[era]
+    bag = [Marble.DO_NOTHING]*config.nothing_list[era] + [Marble.MAJOR_MUTATION]*config.random_list[era] + \
+          [Marble.NAB_INSTRUCTION]*config.nab_list[era] + [Marble.MINOR_MUTATION]*config.mini_mut_list[era] + \
+          [Marble.MICRO_MUTATION]*config.micro_mut_list[era] + [Marble.INSTRUCTION_LIBRARY]*config.library_list[era] + \
+          [Marble.MAGIC_NUMBER_MUTATION]*config.magic_number_list[era]
 
-  print ("{0:.2f}".format(CLOCK_TIME-runtime_in_hours) + \
-         " hours remaining ({0:.2f}%".format(runtime_in_hours/CLOCK_TIME*100)+" complete) Era: "+str(era+1))
-  
+  print ("{0:.2f}".format(config.clock_time-runtime_in_hours) + \
+         " hours remaining ({0:.2f}%".format(runtime_in_hours/config.clock_time*100)+" complete) Era: "+str(era+1))
+
   #in a random arena
-  arena=random.randint(0, LAST_ARENA)
+  arena=random.randint(0, config.last_arena)
   #two random warriors
-  cont1 = random.randint(1, NUMWARRIORS)
+  cont1 = random.randint(1, config.numwarriors)
   cont2 = cont1
   while cont2 == cont1: #no self fights
-    cont2 = random.randint(1, NUMWARRIORS)
-  if BATTLE_ENGINE == 'internal':
-    raw_output = run_internal_battle(arena, cont1, cont2, CORESIZE_LIST[arena], CYCLES_LIST[arena], \
-                                     PROCESSES_LIST[arena], WARLEN_LIST[arena], \
-                                     WARDISTANCE_LIST[arena], BATTLEROUNDS_LIST[era])
+    cont2 = random.randint(1, config.numwarriors)
+  if config.battle_engine == 'internal':
+    raw_output = run_internal_battle(
+      arena,
+      cont1,
+      cont2,
+      config.coresize_list[arena],
+      config.cycles_list[arena],
+      config.processes_list[arena],
+      config.warlen_list[arena],
+      config.wardistance_list[arena],
+      config.battlerounds_list[era],
+    )
   else:
-    raw_output = run_nmars_command(arena, cont1, cont2, CORESIZE_LIST[arena], CYCLES_LIST[arena], \
-                                   PROCESSES_LIST[arena], WARLEN_LIST[arena], \
-                                   WARDISTANCE_LIST[arena], BATTLEROUNDS_LIST[era])
+    raw_output = run_nmars_command(
+      arena,
+      cont1,
+      cont2,
+      config.coresize_list[arena],
+      config.cycles_list[arena],
+      config.processes_list[arena],
+      config.warlen_list[arena],
+      config.wardistance_list[arena],
+      config.battlerounds_list[era],
+    )
   if raw_output is None:
     raise RuntimeError("Battle engine returned no output")
   if isinstance(raw_output, bytes):
@@ -592,7 +651,7 @@ while(True):
     winner=warriors[0]
     loser=warriors[1]
 
-  if ARCHIVE_LIST[era]!=0 and random.randint(1,ARCHIVE_LIST[era])==1:
+  if config.archive_list[era]!=0 and random.randint(1,config.archive_list[era])==1:
     #archive winner
     print("storing in archive")
     with open(os.path.join(f"arena{arena}", f"{winner}.red"), "r") as fw:
@@ -601,7 +660,7 @@ while(True):
       for line in winlines:
         fd.write(line)
 
-  if UNARCHIVE_LIST[era]!=0 and random.randint(1,UNARCHIVE_LIST[era])==1:
+  if config.unarchive_list[era]!=0 and random.randint(1,config.unarchive_list[era])==1:
     print("unarchiving")
     #replace loser with something from archive
     with open(os.path.join("archive", random.choice(os.listdir("archive")))) as fs:
@@ -621,9 +680,9 @@ while(True):
         continue
       fl.write(instruction_to_line(instruction, arena))
       instructions_written=instructions_written+1
-      if instructions_written>=WARLEN_LIST[arena]:
+      if instructions_written>=config.warlen_list[arena]:
         break
-    while instructions_written<WARLEN_LIST[arena]:
+    while instructions_written<config.warlen_list[arena]:
       fl.write(instruction_to_line(default_instruction(), arena))
       instructions_written=instructions_written+1
     fl.close()
@@ -632,17 +691,17 @@ while(True):
   #the loser is destroyed and the winner can breed with any warrior in the arena  
   with open(os.path.join(f"arena{arena}", f"{winner}.red"), "r") as fw:
     winlines = fw.readlines()
-  randomwarrior=str(random.randint(1, NUMWARRIORS))
+  randomwarrior=str(random.randint(1, config.numwarriors))
   print("winner will breed with "+randomwarrior)
   fr = open(os.path.join(f"arena{arena}", f"{randomwarrior}.red"), "r")  # winner mates with random warrior
   ranlines = fr.readlines()
   fr.close()
   fl = open(os.path.join(f"arena{arena}", f"{loser}.red"), "w")  # winner destroys loser
-  if random.randint(1, TRANSPOSITIONRATE_LIST[era])==1: #shuffle a warrior
+  if random.randint(1, config.transpositionrate_list[era])==1: #shuffle a warrior
     print("Transposition")
-    for i in range(1, random.randint(1, int((WARLEN_LIST[arena]+1)/2))):
-      fromline=random.randint(0,WARLEN_LIST[arena]-1)
-      toline=random.randint(0,WARLEN_LIST[arena]-1)
+    for i in range(1, random.randint(1, int((config.warlen_list[arena]+1)/2))):
+      fromline=random.randint(0,config.warlen_list[arena]-1)
+      toline=random.randint(0,config.warlen_list[arena]-1)
       if random.randint(1,2)==1: #either shuffle the winner with itself or shuffle loser with itself
         templine=winlines[toline]
         winlines[toline]=winlines[fromline]
@@ -651,16 +710,16 @@ while(True):
         templine=ranlines[toline]
         ranlines[toline]=ranlines[fromline]
         ranlines[fromline]=templine
-  if PREFER_WINNER_LIST[era]==True:  
+  if config.prefer_winner_list[era]==True:
     pickingfrom=1 #if start picking from the winning warrior, more chance of winning genes passed on.
   else:
     pickingfrom=random.randint(1,2)
 
-  magic_number = weighted_random_number(CORESIZE_LIST[arena], WARLEN_LIST[arena])
-  for i in range(0, WARLEN_LIST[arena]):
+  magic_number = weighted_random_number(config.coresize_list[arena], config.warlen_list[arena])
+  for i in range(0, config.warlen_list[arena]):
     #first, pick an instruction from either parent, even if
     #it will get overwritten by a nabbed or random instruction
-    if random.randint(1,CROSSOVERRATE_LIST[era])==1:
+    if random.randint(1,config.crossoverrate_list[era])==1:
       if pickingfrom==1:
         pickingfrom=2
       else:
@@ -676,13 +735,13 @@ while(True):
     if chosen_marble==Marble.MAJOR_MUTATION: #completely random
       print("Major mutation")
       instruction=generate_random_instruction(arena)
-    elif chosen_marble==Marble.NAB_INSTRUCTION and (LAST_ARENA!=0):
+    elif chosen_marble==Marble.NAB_INSTRUCTION and (config.last_arena!=0):
       #nab instruction from another arena. Doesn't make sense if not multiple arenas
-      donor_arena=random.randint(0, LAST_ARENA)
+      donor_arena=random.randint(0, config.last_arena)
       while (donor_arena==arena):
-        donor_arena=random.randint(0, LAST_ARENA)
+        donor_arena=random.randint(0, config.last_arena)
       print("Nab instruction from arena " + str(donor_arena))
-      donor_file=os.path.join(f"arena{donor_arena}", f"{random.randint(1, NUMWARRIORS)}.red")
+      donor_file=os.path.join(f"arena{donor_arena}", f"{random.randint(1, config.numwarriors)}.red")
       with open(donor_file, "r") as donor_handle:
         donor_lines=donor_handle.readlines()
       if donor_lines:
@@ -699,11 +758,11 @@ while(True):
       elif r==3:
         instruction.a_mode=choose_random_mode()
       elif r==4:
-        instruction.a_field=weighted_random_number(CORESIZE_LIST[arena], WARLEN_LIST[arena])
+        instruction.a_field=weighted_random_number(config.coresize_list[arena], config.warlen_list[arena])
       elif r==5:
         instruction.b_mode=choose_random_mode()
       elif r==6:
-        instruction.b_field=weighted_random_number(CORESIZE_LIST[arena], WARLEN_LIST[arena])
+        instruction.b_field=weighted_random_number(config.coresize_list[arena], config.warlen_list[arena])
     elif chosen_marble==Marble.MICRO_MUTATION: #modifies one number by +1 or -1
       print ("Micro mutation")
       if random.randint(1,2)==1:
@@ -720,9 +779,9 @@ while(True):
         else:
           current_value=current_value-1
         instruction.b_field=current_value
-    elif chosen_marble==Marble.INSTRUCTION_LIBRARY and LIBRARY_PATH and os.path.exists(LIBRARY_PATH):
+    elif chosen_marble==Marble.INSTRUCTION_LIBRARY and config.library_path and os.path.exists(config.library_path):
       print("Instruction library")
-      with open(LIBRARY_PATH, "r") as library_handle:
+      with open(config.library_path, "r") as library_handle:
         library_lines=library_handle.readlines()
       if library_lines:
         instruction=parse_instruction_or_default(random.choice(library_lines))


### PR DESCRIPTION
## Summary
- add an `EvolverConfig` dataclass and loader that reads all values from `settings.ini`
- replace global configuration constants with a single `config` instance throughout the evolver workflow
- update mutation, seeding, and battle routines to reference configuration values via the new object

## Testing
- python -m compileall evolverstage.py

------
https://chatgpt.com/codex/tasks/task_e_68d469e7f3f08330975c98465032054a