### PR TITLE
Add optional final tournament mode

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -39,9 +39,12 @@ CLOCK_TIME=24.0
 BATTLE_LOG_FILE=battle_log.csv
 #log file to study progress. leave blank for no log
 
-FINAL_ERA_ONLY=False 
+FINAL_ERA_ONLY=False
 #if True, skip the first two eras and go straight to the last one(i.e. if you want to continue fine-tuning where you left off)
 #Or you're doing other research into the parameters and don't want them changing.
+
+RUN_FINAL_TOURNAMENT=False
+#When True, run a round-robin tournament in each arena after evolution completes.
 
 #Five strategies for mutating a single instruction. Think of it like a bag of marbles of six different colours, and a different number of each colour.
 


### PR DESCRIPTION
## Summary
- add a RUN_FINAL_TOURNAMENT configuration flag and surface it on the evolver configuration object
- introduce helpers to reuse battle execution logic and run an optional post-evolution round-robin per arena
- update the main evolution loop to exit cleanly on completion/interruption and trigger the final tournament when enabled

## Testing
- pytest tests/test_evolverstage.py tests/test_redcode_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d4798a07688330859eea74bc00c434