### PR TITLE
Clarify build guidance and psutil feature status

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ Evolver output will now rewrite numbers either negative or positive, whichever i
 11. (New) Optional log file
 Results of battles saved so you can analyse your progress. Current fields are 'era', 'arena', 'winner', 'loser', 'score1', 'score2', and 'bred_with'. Edit BATTLE_LOG_FILE setting to choose a file name; comment out or leave blank for no log.
 
+12. Experimental CPU throttling support (disabled)
+        The source includes commented-out hooks to integrate with the `psutil` Python package so the evolver can pause itself when overall CPU usage is high. The feature is currently experimental and therefore disabled by default. To try it, install `psutil` (`pip install psutil`), uncomment the `import psutil` line near the top of `evolverstage.py`, and restore the commented loop at the bottom of the file that checks `psutil.cpu_percent()`. Adjust the threshold to suit your system.
+
 ## Compiling `redcode-worker.cpp`
 
 An experimental C++ worker (`redcode-worker.cpp`) can be built as a shared library for use with the Python evolver.
 
 ### Building with CMake (recommended)
 
-We recommend using CMake to build the C++ worker, as it handles platform differences automatically.
+CMake is the recommended build system because it selects the correct compiler and linker flags for your platform automatically, making the process consistent across Windows, macOS, and Linux.
 
 1.  Create a build directory: `mkdir build && cd build`
 2.  Run CMake: `cmake ..`


### PR DESCRIPTION
## Summary
- clarify that CMake is the preferred, cross-platform way to build `redcode-worker.cpp`
- document the experimental, disabled `psutil`-based CPU throttling feature and how to enable it

## Testing
- pytest tests/test_evolverstage.py tests/test_redcode_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d47c502018833094b3285af9282c39