### PR TITLE
Handle SEQ opcode alias consistently

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -297,7 +297,7 @@ ADDRESSING_MODES.update({'$', '#', '@', '<', '>', '*', '{', '}'})
 
 CANONICAL_SUPPORTED_OPCODES = {
     'DAT', 'MOV', 'ADD', 'SUB', 'MUL', 'DIV', 'MOD',
-    'JMP', 'JMZ', 'JMN', 'DJN', 'CMP', 'SNE', 'SLT', 'SPL', 'NOP',
+    'JMP', 'JMZ', 'JMN', 'DJN', 'CMP', 'SEQ', 'SNE', 'SLT', 'SPL', 'NOP',
 }
 OPCODE_ALIASES = {
     'SEQ': 'CMP',

--- a/redcode-worker.cpp
+++ b/redcode-worker.cpp
@@ -83,9 +83,10 @@ const std::map<std::string, Modifier> MODIFIER_MAP = {
 // Reverse lookups for logging
 const char* OPCODE_NAMES[] = {
     "DAT", "MOV", "ADD", "SUB", "MUL", "DIV", "MOD",
-    "JMP", "JMZ", "JMN", "DJN", "CMP", "SLT", "SPL",
+    "JMP", "JMZ", "JMN", "DJN", "CMP/SEQ", "SLT", "SPL",
     "SNE", "NOP", "ORG"
 };
+// Note: The CMP entry also covers the SEQ alias, which canonicalizes to CMP.
 
 const char* MODIFIER_NAMES[] = {
     "A", "B", "AB", "BA", "F", "X", "I"


### PR DESCRIPTION
## Summary
- allow SEQ to pass validation by listing it in the canonical supported opcode set
- update the C++ worker's opcode logging labels to mention the CMP/SEQ relationship

## Testing
- pytest tests/test_evolverstage.py tests/test_redcode_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d48264475083309f9ffae6b1944207