### PR TITLE
Refactor pairwise CLI target extraction logic

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -2593,6 +2593,29 @@ def _get_arena_idx(default=0):
 
     return default
 
+def _extract_pairwise_targets(idx):
+    """
+    Extracts up to two raw target selectors from command line arguments starting at idx.
+    Provides smart defaults (top1 vs top2) if one or both are missing.
+    """
+    targets = []
+    for i in range(idx + 1, len(sys.argv)):
+        if sys.argv[i].startswith('-'):
+            break
+        targets.append(sys.argv[i])
+
+    if len(targets) == 0:
+        return "top1", "top2"
+
+    t1 = targets[0]
+    if len(targets) == 1:
+        # Default: Target vs Top (or Top2 if Target is Top)
+        t2 = "top2" if t1.lower() in ["top", "top1"] else "top1"
+    else:
+        t2 = targets[1]
+
+    return t1, t2
+
 def validate_configuration():
     """
     Checks if the project is ready to run.
@@ -2977,24 +3000,7 @@ if __name__ == "__main__":
         idx = sys.argv.index("--battle") if "--battle" in sys.argv else sys.argv.index("-b")
         arena_idx = _get_arena_idx()
 
-        # Extract up to 2 warrior arguments that are not flags
-        targets = []
-        for i in range(idx + 1, len(sys.argv)):
-            if sys.argv[i].startswith('-'):
-                break
-            targets.append(sys.argv[i])
-
-        if len(targets) == 0:
-            # Default: Top vs Top2
-            w1_path = "top1"
-            w2_path = "top2"
-        elif len(targets) == 1:
-            # Default: Target vs Top (or Top2 if Target is Top)
-            w1_path = targets[0]
-            w2_path = "top2" if w1_path.lower() in ["top", "top1"] else "top1"
-        else:
-            w1_path = targets[0]
-            w2_path = targets[1]
+        w1_path, w2_path = _extract_pairwise_targets(idx)
 
         w1 = _resolve_warrior_path(w1_path, arena_idx)
         w2 = _resolve_warrior_path(w2_path, arena_idx)
@@ -3234,22 +3240,7 @@ if __name__ == "__main__":
           idx = sys.argv.index("--compare") if "--compare" in sys.argv else sys.argv.index("-y")
           arena_idx = _get_arena_idx()
 
-          # Extract up to 2 warrior arguments that are not flags
-          targets = []
-          for i in range(idx + 1, len(sys.argv)):
-              if sys.argv[i].startswith('-'):
-                  break
-              targets.append(sys.argv[i])
-
-          if len(targets) == 0:
-              t1 = "top1"
-              t2 = "top2"
-          elif len(targets) == 1:
-              t1 = targets[0]
-              t2 = "top2" if t1.lower() in ["top", "top1"] else "top1"
-          else:
-              t1 = targets[0]
-              t2 = targets[1]
+          t1, t2 = _extract_pairwise_targets(idx)
 
           json_output = "--json" in sys.argv
 
@@ -3264,22 +3255,7 @@ if __name__ == "__main__":
           idx = sys.argv.index("--diff") if "--diff" in sys.argv else sys.argv.index("-f")
           arena_idx = _get_arena_idx()
 
-          # Extract up to 2 warrior arguments that are not flags
-          targets = []
-          for i in range(idx + 1, len(sys.argv)):
-              if sys.argv[i].startswith('-'):
-                  break
-              targets.append(sys.argv[i])
-
-          if len(targets) == 0:
-              t1 = "top1"
-              t2 = "top2"
-          elif len(targets) == 1:
-              t1 = targets[0]
-              t2 = "top2" if t1.lower() in ["top", "top1"] else "top1"
-          else:
-              t1 = targets[0]
-              t2 = targets[1]
+          t1, t2 = _extract_pairwise_targets(idx)
 
           run_diff(t1, t2, arena_idx)
           sys.exit(0)

--- a/tests/test_pairwise_extraction.py
+++ b/tests/test_pairwise_extraction.py
@@ -1,0 +1,59 @@
+import sys
+import os
+import unittest
+from unittest import mock
+
+# Add the root directory to sys.path so we can import evolverstage
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import evolverstage
+
+class TestPairwiseExtraction(unittest.TestCase):
+    def test_extract_no_targets(self):
+        """Test extraction when no targets are provided."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "top1")
+            self.assertEqual(t2, "top2")
+
+    def test_extract_one_target_not_top(self):
+        """Test extraction when one non-top target is provided."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', 'warrior1.red']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "warrior1.red")
+            self.assertEqual(t2, "top1")
+
+    def test_extract_one_target_is_top(self):
+        """Test extraction when one target 'top' is provided."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', 'top']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "top")
+            self.assertEqual(t2, "top2")
+
+    def test_extract_one_target_is_top1(self):
+        """Test extraction when one target 'top1' is provided."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', 'top1']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "top1")
+            self.assertEqual(t2, "top2")
+
+    def test_extract_two_targets(self):
+        """Test extraction when two targets are provided."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', 'w1.red', 'w2.red']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "w1.red")
+            self.assertEqual(t2, "w2.red")
+
+    def test_extract_targets_before_next_flag(self):
+        """Test that extraction stops at the next flag."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', 'w1.red', '--arena', '2']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "w1.red")
+            self.assertEqual(t2, "top1")
+
+    def test_extract_zero_targets_before_next_flag(self):
+        """Test extraction with no targets before the next flag."""
+        with mock.patch.object(sys, 'argv', ['evolverstage.py', '--battle', '--arena', '2']):
+            t1, t2 = evolverstage._extract_pairwise_targets(1)
+            self.assertEqual(t1, "top1")
+            self.assertEqual(t2, "top2")


### PR DESCRIPTION
The target extraction logic for pairwise CLI commands (`--battle`, `--compare`, `--diff`) in `evolverstage.py` was refactored into a private helper function `_extract_pairwise_targets(idx)` to eliminate code duplication and ensure consistent application of smart defaults. This change improves maintainability while preserving identical external behavior. Verification was performed via a new test suite and the existing full test package.

---
*PR created automatically by Jules for task [2119920474728987093](https://jules.google.com/task/2119920474728987093) started by @RainRat*