### PR TITLE
Refine error handling in get_evolution_status

### DIFF
--- a/evolverstage.py
+++ b/evolverstage.py
@@ -1489,7 +1489,7 @@ def get_evolution_status(arena_idx=None):
                     try:
                         with open(os.path.join(dir_name, f), 'r') as fh:
                             total_lines += sum(1 for line in fh if line.strip())
-                    except:
+                    except (OSError, UnicodeDecodeError):
                         pass
                 arena_info["avg_length"] = total_lines / len(sample_files)
 


### PR DESCRIPTION
This pull request resolves an instance of "Error Handling Noise" in the `evolverstage.py` module.

### What:
The broad `except:` block in `get_evolution_status` (used for calculating the average code length of a sample of warriors) has been replaced with specific exception handling for `OSError` and `UnicodeDecodeError`.

### Why:
Bare `except:` blocks are considered poor practice in Python because they catch all exceptions, including those that should typically be allowed to propagate, such as `KeyboardInterrupt` (Ctrl+C) and `SystemExit`. This can lead to unresponsive scripts or difficult-to-debug logic errors. By narrowing the scope to expected file-related issues, we ensure the code remains resilient to missing or corrupted files without masking critical process signals or unrelated bugs.

### Verification:
- All 242 unit tests passed.
- Verified CLI functionality with `python evolverstage.py --status`.
- Manually confirmed that unreadable files are still gracefully skipped as intended.

---
*PR created automatically by Jules for task [4394312375249007589](https://jules.google.com/task/4394312375249007589) started by @RainRat*